### PR TITLE
removed broken utf-8 BOM

### DIFF
--- a/testcases/response/status/different status.json
+++ b/testcases/response/status/different status.json
@@ -1,10 +1,10 @@
-﻿{
-	"match": false,
-	"comment": "Status is incorrect",
-	"expected" : {
-		"status" : 202
-	},
-	"actual" : {
-		"status" : 400
-	}
+{
+    "match": false,
+    "comment": "Status is incorrect",
+    "expected": {
+        "status": 202
+    },
+    "actual": {
+        "status": 400
+    }
 }

--- a/testcases/response/status/matches.json
+++ b/testcases/response/status/matches.json
@@ -1,10 +1,10 @@
-﻿{
-	"match": true,
-	"comment": "Status matches",
-	"expected" : {
-		"status" : 202
-	},
-	"actual" : {
-		"status" : 202
-	}
+{
+    "match": true,
+    "comment": "Status matches",
+    "expected": {
+        "status": 202
+    },
+    "actual": {
+        "status": 202
+    }
 }


### PR DESCRIPTION
Python's json module won't load the two response/status test cases, because of a unicode character at the start of the file. (github's diff doesn't show it, but git diff on the terminal will.)